### PR TITLE
Fix logic for matching precinct codes

### DIFF
--- a/src/parsers/parser.py
+++ b/src/parsers/parser.py
@@ -45,7 +45,7 @@ def parse_file(url, counties, precincts):
         result = line.split(';')
         try:
             county = [x['county'] for x in counties if result[1] == x['county_code']][0]
-            precinct = [x['precinct_name'] for x in precincts if result[2] == x['precinct_code']][0]
+            precinct = [x['precinct_name'] for x in precincts if result[2] == x['precinct_code'] and result[1] == x['county_code']][0]
             results.append({"county_code": result[1], "county": county, "precinct_code": result[2], "precinct": precinct, "office_code": result[3], "office": result[4], "district": result[5], "candidate_code": result[6], "candidate": result[7], "party": result[10], "votes": result[13], "pct": result[14]})
         except:
             pass


### PR DESCRIPTION
Issue: #5 

The underlying issue here is that parse_file matches a row from the results url with a row from the precincts url by `precinct_code`, which is not unique state-wide.

So what was happening was, for example, the precinct with a code of `0005` in Anoka County (Andover P-1) was getting assigned to the first precinct it found with a code of `0005`, which was "AITKIN"

I'm pretty confident the one-line fix in parser.py fixes the underlying issue. What I'm not confident in was my process for doing find/replace on the resulting file to normalize office names (for example `"State Representative District...."` -> `"State House"`. If you'd like, I can make a PR for just python change and tackle the csv changes separately.